### PR TITLE
Loosen version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ setuptools.setup(
     url="https://github.com/djentleman/imgrender",
     packages=setuptools.find_packages(),
     install_requires=[
-        'ansicolors==1.1.8',
-        'numpy==1.17.2',
-        'Pillow==6.1.0',
+        'ansicolors>=1.1.8',
+        'numpy>=1.17.2',
+        'Pillow>=6.1.0',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
When trying to install the package from pypi, it breaks my environment because it downgrades numpy (and tries to build Pillow).

I changed the requirements to specify a minimum version instead of an exact version. This will better let imgrender be used alongside other tools that require newer versions of these other libs.

FWIW the way I handle this issue is to use '>=' as the default and then in CI run a search / replace to change '>=' to '==', thus defining a strict minimum req version of the package. This helps test if you broke your CI or an update in a package broke it.